### PR TITLE
Fix broken github pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,13 +2,13 @@
   "name": "DEKA Team Assignment Tool",
   "short_name": "DEKA Teams",
   "description": "Create and manage your DEKA team exercise challenge plans",
-  "start_url": "/",
+  "start_url": "/dopedeka.com/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#e63946",
   "icons": [
     {
-      "src": "/vite.svg",
+      "src": "/dopedeka.com/vite.svg",
       "sizes": "any",
       "type": "image/svg+xml"
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-  base: '/',
+  base: '/dopedeka.com/',
   build: {
     outDir: 'dist',
     sourcemap: false,


### PR DESCRIPTION
Correct GitHub Pages deployment configuration to resolve 404 errors.

The previous configuration caused 404s because the base path for assets was incorrect for GitHub Pages, and single-page application routing was not supported without a `404.html` file.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b58a8bf-3695-4dbc-9d1d-e3dbd60d03a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b58a8bf-3695-4dbc-9d1d-e3dbd60d03a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

